### PR TITLE
Initial support for Wireplumber (Pipewire configs)

### DIFF
--- a/arch/stowme.sh
+++ b/arch/stowme.sh
@@ -7,5 +7,5 @@
 sh $HOME/.dotfiles/linux/zsh/bin/dotfiles-cleanup
 sh $HOME/.dotfiles/linux/zsh/bin/dotfiles-ssh
 cd $HOME || return
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems wireplumber
 exit 0

--- a/debian/stowme.sh
+++ b/debian/stowme.sh
@@ -2,5 +2,5 @@
 sh $HOME/.dotfiles/linux/zsh/bin/dotfiles-cleanup
 sh $HOME/.dotfiles/linux/zsh/bin/dotfiles-ssh
 cd $HOME || return
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems wireplumber
 exit 0

--- a/linux/wireplumber/.config/wireplumber/wireplumber.conf.d/51-priority-override.conf
+++ b/linux/wireplumber/.config/wireplumber/wireplumber.conf.d/51-priority-override.conf
@@ -1,0 +1,55 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.nick = "HDMI"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.driver = 500
+        priority.session = 500
+      }
+    }
+  },
+  {
+    matches = [
+      {
+        node.nick = "Speaker"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.driver = 800
+        priority.session = 800
+      }
+    }
+  },
+  {
+    matches = [
+      {
+        node.nick = "Headphones"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.driver = 900
+        priority.session = 900
+      }
+    }
+  },
+  {
+    matches = [
+      {
+        node.driver = "true"
+        node.name = "jamesdsp_sink"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.driver = 1100
+        priority.session = 1100
+      }
+    }
+  },
+]

--- a/rhel/stowme.sh
+++ b/rhel/stowme.sh
@@ -5,6 +5,6 @@ cd $HOME || return
 # Workaround for Fedora
 export LD_PRELOAD="/usr/lib64/libgcrypt.so.20"
 # Generic
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems wireplumber
 export LD_PRELOAD=
 exit 0

--- a/ubuntu/stowme.sh
+++ b/ubuntu/stowme.sh
@@ -2,5 +2,5 @@
 sh $HOME/.dotfiles/linux/zsh/bin/dotfiles-cleanup
 sh $HOME/.dotfiles/linux/zsh/bin/dotfiles-ssh
 cd $HOME || return
-dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems
+dotstow stow bash zsh git antigen tmux tmuxp vim vscode dxvk systems wireplumber
 exit 0


### PR DESCRIPTION
To resolve the following:

- [x] HDMI not being handled properly when it's plugged, but some monitors does not have any audio chip/support.
- [x] Prioritize internal devices over external (e.g. HDMI, Thunderport, etc.)